### PR TITLE
feat: Add the cleanup logic for input_volume

### DIFF
--- a/refiner/utils/docker.py
+++ b/refiner/utils/docker.py
@@ -201,7 +201,7 @@ def run_signed_container(
         raise
 
     finally:
-        # Clean up main container and output volume
+        # Clean up main container and volumes
         try:
             if container:
                 vana.logging.info(f"Removing container: {container_name}")
@@ -210,6 +210,15 @@ def run_signed_container(
              vana.logging.info(f"Container {container_name} already removed during cleanup.")
         except Exception as e:
             vana.logging.error(f"Error removing container {container_name}: {str(e)}")
+
+        try:
+            if input_volume:
+                vana.logging.info(f"Removing input volume: {input_volume_name}")
+                input_volume.remove(force=True)
+        except docker.errors.NotFound:
+             vana.logging.info(f"Input volume {input_volume_name} already removed during cleanup.")
+        except Exception as e:
+            vana.logging.error(f"Error removing input volume {input_volume_name}: {str(e)}")
 
         try:
             if output_volume:


### PR DESCRIPTION
The primary cause of the disk space leak is in `refiner/utils/docker.py`. For every refinement request, the service creates two named Docker volumes (`input-<uuid>` and `output-<uuid>`), but it only cleans up one of them (`output-<uuid>`). The input-`<uuid>` volume is abandoned after each request, accumulating indefinitely and consuming disk space until the system is restarted. This PR fixes the issue.